### PR TITLE
Update vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "rewrites": [
     {
       "source": "/api/:path*",
-      "destination": "https://script.google.com/macros/s/AKfycbxayc7cTSeMNPPBdyll2MjK3wIrorxS1RJNg9y7hEU41eS6lROJVnBirA_4lDXK12mEhw/exec"
+      "destination": "https://script.google.com/macros/s/AKfycbx0j8BFs_yf5IyYJIyr-7By5U2xEzUfV0Fa7HPD0r2Hq739fCqIl2JXm9POQmiIV17gGw/exec"
     }
   ]
 }


### PR DESCRIPTION
更新 vercel.json 中的 Google Apps Script URL，以修正前端與後端連線失敗的問題（404 NOT FOUND）。新的 URL 是來自最新的 Google Apps Script 部署，預計解決試算表未收到資料的問題。